### PR TITLE
[MIN-32] implement reusable AccountDto

### DIFF
--- a/backend/src/main/java/org/minttwo/api/AccountDto.java
+++ b/backend/src/main/java/org/minttwo/api/AccountDto.java
@@ -1,0 +1,12 @@
+package org.minttwo.api;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class AccountDto {
+    private String id;
+    private String userId;
+    private double balance;
+}

--- a/backend/src/main/java/org/minttwo/api/ListAccountsResponseDto.java
+++ b/backend/src/main/java/org/minttwo/api/ListAccountsResponseDto.java
@@ -2,12 +2,11 @@ package org.minttwo.api;
 
 import lombok.Builder;
 import lombok.Data;
-import org.minttwo.models.Account;
 
 import java.util.List;
 
 @Builder
 @Data
 public class ListAccountsResponseDto {
-    private List<Account> accounts;
+    private List<AccountDto> accounts;
 }

--- a/backend/src/main/java/org/minttwo/api/adapters/AccountAdapter.java
+++ b/backend/src/main/java/org/minttwo/api/adapters/AccountAdapter.java
@@ -1,0 +1,15 @@
+package org.minttwo.api.adapters;
+
+import lombok.NonNull;
+import org.minttwo.api.AccountDto;
+import org.minttwo.models.Account;
+
+public class AccountAdapter {
+    public AccountDto adapt(@NonNull Account account) {
+        return AccountDto.builder()
+                .id(account.getId())
+                .userId(account.getUserId())
+                .balance(account.getBalance())
+                .build();
+    }
+}

--- a/backend/src/main/java/org/minttwo/controllers/AccountController.java
+++ b/backend/src/main/java/org/minttwo/controllers/AccountController.java
@@ -1,6 +1,8 @@
 package org.minttwo.controllers;
 
+import org.minttwo.api.AccountDto;
 import org.minttwo.api.ListAccountsResponseDto;
+import org.minttwo.api.adapters.AccountAdapter;
 import org.minttwo.dataclients.AccountClient;
 import org.minttwo.models.Account;
 import org.springframework.http.ResponseEntity;
@@ -13,9 +15,11 @@ import java.util.List;
 @RequestMapping("/account")
 public class AccountController implements AccountApi {
     private final AccountClient accountClient;
+    private final AccountAdapter accountAdapter;
 
     public AccountController(AccountClient accountClient) {
         this.accountClient = accountClient;
+        this.accountAdapter = new AccountAdapter();
     }
 
     @Override
@@ -31,9 +35,12 @@ public class AccountController implements AccountApi {
     @Override
     public ResponseEntity<ListAccountsResponseDto> listAccounts(String userId) {
         List<Account> accounts = accountClient.loadAccountsByUserId(userId);
+        List<AccountDto> accountDtos = accounts.stream()
+                .map(accountAdapter::adapt)
+                .toList();
 
         ListAccountsResponseDto listAccountsDto = ListAccountsResponseDto.builder()
-                .accounts(accounts)
+                .accounts(accountDtos)
                 .build();
 
         return ResponseEntity.ok(listAccountsDto);

--- a/backend/src/test/java/org/minttwo/controllers/AccountControllerTest.java
+++ b/backend/src/test/java/org/minttwo/controllers/AccountControllerTest.java
@@ -2,6 +2,7 @@ package org.minttwo.controllers;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.minttwo.api.AccountDto;
 import org.minttwo.api.ListAccountsResponseDto;
 import org.minttwo.dataclients.AccountClient;
 import org.minttwo.models.Account;
@@ -69,21 +70,27 @@ public class AccountControllerTest {
     @Test
     void listAccountsSuccess(){
         int numAccounts = 10;
-        List<Account> expectedAccounts = new ArrayList<>();
+        List<Account> expectedAccountsList = new ArrayList<>();
         for (int i = 0; i < numAccounts; i++) {
             Account account = buildAccount(i);
-            expectedAccounts.add(account);
+            expectedAccountsList.add(account);
         }
 
-       when(accountClient.loadAccountsByUserId(anyString())).thenReturn(expectedAccounts);
+       when(accountClient.loadAccountsByUserId(anyString())).thenReturn(expectedAccountsList);
 
         ResponseEntity<ListAccountsResponseDto> listAccountsDto = subject.listAccounts(TEST_USER_ID);
-        List<Account> testAccounts = Optional.ofNullable(listAccountsDto.getBody())
+        List<AccountDto> testAccountsList = Optional.ofNullable(listAccountsDto.getBody())
                         .map(ListAccountsResponseDto::getAccounts)
                         .orElse(Collections.emptyList());
 
-        assertThat(testAccounts.size()).isEqualTo(expectedAccounts.size());
-        assertThat(testAccounts).containsExactlyElementsOf(expectedAccounts);
+
+        AccountDto testAccount = testAccountsList.getFirst();
+        Account expectedAccount = expectedAccountsList.getFirst();
+
+        assertThat(testAccountsList.size()).isEqualTo(expectedAccountsList.size());
+        assertThat(testAccount.getId()).isEqualTo(expectedAccount.getId());
+        assertThat(testAccount.getUserId()).isEqualTo(expectedAccount.getUserId());
+        assertThat(testAccount.getBalance()).isEqualTo(expectedAccount.getBalance());
     }
 
     private Account buildAccount(int index) {


### PR DESCRIPTION
- implemented reusable account dto to be shared among account APIs
- we want to make a separate dto for account data so we don't expose vulnerabilities that come with exposing the account object directly