### PR TITLE
[MIN-30] implement 400 BadRequest case for CreateAccount API

### DIFF
--- a/backend/src/main/java/org/minttwo/dataclients/AccountClient.java
+++ b/backend/src/main/java/org/minttwo/dataclients/AccountClient.java
@@ -3,6 +3,7 @@ package org.minttwo.dataclients;
 import lombok.NonNull;
 import org.minttwo.exception.NotFoundException;
 import org.minttwo.models.Account;
+import org.minttwo.validators.AccountValidator;
 
 import java.util.List;
 import java.util.UUID;
@@ -10,11 +11,16 @@ import java.util.UUID;
 public class AccountClient extends DataClient<Account> {
     private static final String USER_ID_FIELD_NAME = "userId";
 
+    private final AccountValidator validator;
+
     public AccountClient(Db db) {
         super(db);
+        this.validator = new AccountValidator();
     }
 
     public void createAccount(@NonNull Account account) {
+        validator.validate(account);
+
         String id = UUID.randomUUID().toString();
         account.setId(id);
 

--- a/backend/src/main/java/org/minttwo/dataclients/DataClient.java
+++ b/backend/src/main/java/org/minttwo/dataclients/DataClient.java
@@ -26,6 +26,7 @@ public abstract class DataClient<T> {
             transaction.commit();
         } catch (Exception e) {
             if (transaction != null) transaction.rollback();
+            throw e;
         }
     }
 

--- a/backend/src/main/java/org/minttwo/exception/BadRequestException.java
+++ b/backend/src/main/java/org/minttwo/exception/BadRequestException.java
@@ -1,0 +1,10 @@
+package org.minttwo.exception;
+
+import jakarta.annotation.Nullable;
+import lombok.NonNull;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(@NonNull String message, @Nullable Exception e) {
+        super(message, e);
+    }
+}

--- a/backend/src/main/java/org/minttwo/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/org/minttwo/exception/GlobalExceptionHandler.java
@@ -8,10 +8,19 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+    private static final int BAD_REQUEST_STATUS_CODE = 400;
     private static final int NOT_FOUND_STATUS_CODE = 404;
 
+    @ExceptionHandler({BadRequestException.class})
+    public ResponseEntity<ErrorDto> handleBadRequestException(@NonNull BadRequestException exception) {
+        ErrorDto errorDto = buildErrorDto(exception, BAD_REQUEST_STATUS_CODE);
+        return ResponseEntity
+                .status(BAD_REQUEST_STATUS_CODE)
+                .body(errorDto);
+    }
+
     @ExceptionHandler({NotFoundException.class})
-    public ResponseEntity<ErrorDto> handleUnsupportedOperation(@NonNull NotFoundException exception) {
+    public ResponseEntity<ErrorDto> handleNotFoundException(@NonNull NotFoundException exception) {
         ErrorDto errorDto = buildErrorDto(exception, NOT_FOUND_STATUS_CODE);
         return ResponseEntity
                 .status(NOT_FOUND_STATUS_CODE)

--- a/backend/src/main/java/org/minttwo/models/Account.java
+++ b/backend/src/main/java/org/minttwo/models/Account.java
@@ -24,5 +24,5 @@ public class Account {
     private String userId;
 
     @Column(name = "balance")
-    private double balance;
+    private Double balance;
 }

--- a/backend/src/main/java/org/minttwo/validators/AccountValidator.java
+++ b/backend/src/main/java/org/minttwo/validators/AccountValidator.java
@@ -1,0 +1,17 @@
+package org.minttwo.validators;
+
+import lombok.NonNull;
+import org.minttwo.exception.BadRequestException;
+import org.minttwo.models.Account;
+
+public class AccountValidator {
+    public void validate(@NonNull Account account) {
+        if (account.getUserId() == null || account.getUserId().isEmpty()) {
+            throw new BadRequestException("UserId is required and cannot be blank", null);
+        }
+
+        if (account.getBalance() == null) {
+            throw new BadRequestException("Balance is required", null);
+        }
+    }
+}


### PR DESCRIPTION
- utilized validator class to validate account data before it is passed to db layer
- created custom BadRequest exception to be shared among all 400 exceptions within all API Controllers
