### PR TITLE
[MIN-38] unit test for 404 scenario when calling GetAccount API

### DIFF
--- a/backend/src/main/java/org/minttwo/dataclients/DataClient.java
+++ b/backend/src/main/java/org/minttwo/dataclients/DataClient.java
@@ -26,7 +26,11 @@ public abstract class DataClient<T> {
             transaction.commit();
         } catch (Exception e) {
             if (transaction != null) transaction.rollback();
+<<<<<<< Updated upstream
             throw e;
+=======
+            System.out.println(e.getMessage());
+>>>>>>> Stashed changes
         }
     }
 

--- a/backend/src/test/java/org/minttwo/controllers/UserControllerTest.java
+++ b/backend/src/test/java/org/minttwo/controllers/UserControllerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.minttwo.api.GetUserResponseDto;
 import org.minttwo.api.UserDto;
 import org.minttwo.dataclients.UserClient;
+import org.minttwo.exception.NotFoundException;
 import org.minttwo.models.User;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.when;
 public class UserControllerTest {
 
     private static final String TEST_USER_ID = "TEST_USER_ID";
+    private static final String TEST_USER_ID_PREFIX = "TEST_USER_ID_PREFIX";
 
     @Mock
     private UserClient userClient;
@@ -63,6 +66,18 @@ public class UserControllerTest {
         assertThat(testUser.getId()).isEqualTo(expectedUser.getId());
         assertThat(testUser.getUsername()).isEqualTo(expectedUser.getUsername());
         assertThat(testUser.getEmail()).isEqualTo(expectedUser.getEmail());
+    }
+
+    @Test
+    void whenCallingGetUser_ResourceNotFound() {
+        int userNumber = 1;
+        String userId = TEST_USER_ID_PREFIX + userNumber;
+        String expectedErrMessage = String.format("User with id %s not found", userId);
+        when(userClient.getUserById(anyString()))
+                .thenThrow(new NotFoundException(expectedErrMessage, null));
+        assertThatThrownBy(() -> subject.getUser(userId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(expectedErrMessage);
     }
 
     private User buildUser() {


### PR DESCRIPTION
- utilized assertThatThrownBy assertion exception for clean code when making checks on exceptions thrown by the lambda parameter consumed by the assertion
- leveraged mockito library to test 404 unhappy path scenario for GetUser API