### PR TITLE
[MIN-11] login API unit test

### DIFF
--- a/backend/src/main/java/org/minttwo/configurations/SecurityConfig.java
+++ b/backend/src/main/java/org/minttwo/configurations/SecurityConfig.java
@@ -1,0 +1,14 @@
+package org.minttwo.configurations;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/org/minttwo/controllers/user/UserController.java
+++ b/backend/src/main/java/org/minttwo/controllers/user/UserController.java
@@ -9,7 +9,6 @@ import org.minttwo.exception.AccessDeniedException;
 import org.minttwo.exception.NotFoundException;
 import org.minttwo.models.User;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,15 +20,22 @@ public class UserController implements UserApi {
     private final UserAdapter userAdapter;
     private final PasswordEncoder passwordEncoder;
 
-    public UserController(UserClient userClient) {
+    public UserController(
+        UserClient userClient,
+        PasswordEncoder passwordEncoder
+    ) {
         this.userClient = userClient;
+        this.passwordEncoder = passwordEncoder;
         this.userAdapter = new UserAdapter();
-        passwordEncoder = new BCryptPasswordEncoder();
     }
 
     @Override
     public ResponseEntity<Void> createUser(User user) {
+        String hashedPassword = passwordEncoder.encode(user.getPassword());
+        user.setPassword(hashedPassword);
+
         userClient.createUser(user);
+
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/org/minttwo/dataclients/UserClient.java
+++ b/backend/src/main/java/org/minttwo/dataclients/UserClient.java
@@ -4,8 +4,6 @@ import lombok.NonNull;
 import org.minttwo.exception.NotFoundException;
 import org.minttwo.models.User;
 import org.minttwo.validators.UserValidator;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -13,12 +11,10 @@ import java.util.UUID;
 public class UserClient extends DataClient<User> {
     private static final String USERNAME_FIELD_NAME = "username";
 
-    private final PasswordEncoder passwordEncoder;
     private final UserValidator validator;
 
     public UserClient(Db db) {
         super(db);
-        this.passwordEncoder = new BCryptPasswordEncoder();
         this.validator = new UserValidator();
     }
 
@@ -26,11 +22,9 @@ public class UserClient extends DataClient<User> {
         validator.validate(user);
 
         String id = UUID.randomUUID().toString();
-        String hashedPassword = passwordEncoder.encode(user.getPassword());
 
         user.setCreatedAt(LocalDateTime.now());
         user.setUpdatedAt(LocalDateTime.now());
-        user.setPassword(hashedPassword);
         user.setId(id);
 
         this.insert(user);


### PR DESCRIPTION
- extracted PasswordEncoder from userClient and userController into Spring Boot Configuration package so that we have control over which encoder to use in which controller
- implemented unit case for 200, 404, and 403 cases when calling loginUser API
- moved password hashing logic to userController so that we can leverage encoder that we opt to use for the UserController
- leveraged mockito library and special thrown by assertion to write clean and readable unit tests
