### PR TITLE
[MIN-43] Add Title Field to GetAccountTransaction API flow

### DIFF
--- a/backend/src/main/java/org/minttwo/api/account/AccountTransactionDto.java
+++ b/backend/src/main/java/org/minttwo/api/account/AccountTransactionDto.java
@@ -8,5 +8,6 @@ import lombok.Data;
 public class AccountTransactionDto {
     private String id;
     private String accountId;
+    private String title;
     private double amount;
 }

--- a/backend/src/main/java/org/minttwo/api/account/adapters/AccountTransactionAdapter.java
+++ b/backend/src/main/java/org/minttwo/api/account/adapters/AccountTransactionAdapter.java
@@ -10,6 +10,7 @@ public class AccountTransactionAdapter {
         return AccountTransactionDto.builder()
                 .id(accountTransaction.getId())
                 .accountId(accountTransaction.getAccountId())
+                .title(accountTransaction.getTitle())
                 .amount(accountTransaction.getAmount())
                 .build();
     }

--- a/backend/src/main/java/org/minttwo/validators/AccountTransactionValidator.java
+++ b/backend/src/main/java/org/minttwo/validators/AccountTransactionValidator.java
@@ -9,6 +9,9 @@ public class AccountTransactionValidator {
         if (accountTransaction.getAccountId() == null || accountTransaction.getAccountId().isEmpty()) {
             throw new BadRequestException("AccountId is required and cannot be blank", null);
         }
+        if (accountTransaction.getTitle() == null || accountTransaction.getTitle().isEmpty()) {
+            throw new BadRequestException("Title is required and cannot be blank", null);
+        }
         if (accountTransaction.getAmount() == null) {
             throw new BadRequestException("Amount is required", null);
         }

--- a/backend/src/test/java/org/minttwo/controllers/AccountControllerTest.java
+++ b/backend/src/test/java/org/minttwo/controllers/AccountControllerTest.java
@@ -192,6 +192,7 @@ public class AccountControllerTest {
         assertNotNull(testAccountTransaction);
         assertThat(testAccountTransaction.getId()).isEqualTo(expectedAccountTransaction.getId());
         assertThat(testAccountTransaction.getAccountId()).isEqualTo(expectedAccountTransaction.getAccountId());
+        assertThat(testAccountTransaction.getTitle()).isEqualTo(expectedAccountTransaction.getTitle());
         assertThat(testAccountTransaction.getAmount()).isEqualTo(expectedAccountTransaction.getAmount());
     }
 


### PR DESCRIPTION
- made title field available when calling GetAccountTransaction API since we baked it into sql table
- updated AccountValidator class to handle validation for title field 
- tested locally with Postman