### PR TITLE
refactor: move class parameter into local variable in DataClient

### DIFF
--- a/backend/src/main/java/org/minttwo/data/DataClient.java
+++ b/backend/src/main/java/org/minttwo/data/DataClient.java
@@ -11,9 +11,11 @@ import java.util.List;
 
 public abstract class DataClient<T> {
     private final Db db;
+    private final Class<T> entityClass;
 
-    public DataClient(Db db) {
+    public DataClient(Db db, Class<T> entityClass) {
         this.db = db;
+        this.entityClass = entityClass;
     }
 
     protected void insert(T data) {
@@ -30,7 +32,7 @@ public abstract class DataClient<T> {
         }
     }
 
-    protected T getById(Class<T> entityClass, String id) {
+    protected T getById(String id) {
         Transaction transaction = null;
         Session session = db.getCurrentSession();
         T data = null;
@@ -46,7 +48,7 @@ public abstract class DataClient<T> {
         return data;
     }
 
-    protected List<T> getByField(Class<T> entityClass, String fieldName, String fieldValue) {
+    protected List<T> getByField(String fieldName, String fieldValue) {
         Transaction transaction = null;
         Session session = db.getCurrentSession();
         List<T> data = Collections.emptyList();
@@ -68,7 +70,7 @@ public abstract class DataClient<T> {
         return data;
     }
 
-    protected T getByUniqueField(Class<T> entityClass, String fieldName, String fieldValue) {
+    protected T getByUniqueField(String fieldName, String fieldValue) {
         Transaction transaction = null;
         Session session = db.getCurrentSession();
         T result = null;

--- a/backend/src/main/java/org/minttwo/data/dataclients/AccountClient.java
+++ b/backend/src/main/java/org/minttwo/data/dataclients/AccountClient.java
@@ -17,7 +17,7 @@ public class AccountClient extends DataClient<AccountModel> {
     private final AccountValidator validator;
 
     public AccountClient(Db db) {
-        super(db);
+        super(db, AccountModel.class);
         this.validator = new AccountValidator();
     }
 
@@ -33,7 +33,7 @@ public class AccountClient extends DataClient<AccountModel> {
     }
 
     public AccountModel loadById(@NonNull String id) {
-        AccountModel accountModel = this.getById(AccountModel.class, id);
+        AccountModel accountModel = this.getById(id);
 
         if (accountModel == null) {
             String errMessage = String.format("Account with id %s not found", id);
@@ -44,6 +44,6 @@ public class AccountClient extends DataClient<AccountModel> {
     }
 
     public List<AccountModel> loadByUserId(@NonNull String userId) {
-        return this.getByField(AccountModel.class, USER_ID_FIELD_NAME, userId);
+        return this.getByField(USER_ID_FIELD_NAME, userId);
     }
 }

--- a/backend/src/main/java/org/minttwo/data/dataclients/AccountTransactionClient.java
+++ b/backend/src/main/java/org/minttwo/data/dataclients/AccountTransactionClient.java
@@ -16,7 +16,7 @@ public class AccountTransactionClient extends DataClient<AccountTransactionModel
     private final AccountTransactionValidator validator;
 
     public AccountTransactionClient(Db db) {
-        super(db);
+        super(db, AccountTransactionModel.class);
         this.validator = new AccountTransactionValidator();
     }
 
@@ -32,8 +32,7 @@ public class AccountTransactionClient extends DataClient<AccountTransactionModel
     }
 
     public AccountTransactionModel loadById(@NonNull String id) {
-        AccountTransactionModel accountTransaction =
-                this.getById(AccountTransactionModel.class, id);
+        AccountTransactionModel accountTransaction = this.getById(id);
 
         if (accountTransaction == null) {
             String errMessage = String.format("AccountTransaction with id %s not found", id);
@@ -44,6 +43,6 @@ public class AccountTransactionClient extends DataClient<AccountTransactionModel
     }
 
     public List<AccountTransactionModel> loadByAccountId(@NonNull String accountId) {
-        return this.getByField(AccountTransactionModel.class, ACCOUNT_ID_FIELD_NAME, accountId);
+        return this.getByField(ACCOUNT_ID_FIELD_NAME, accountId);
     }
 }

--- a/backend/src/main/java/org/minttwo/data/dataclients/UserClient.java
+++ b/backend/src/main/java/org/minttwo/data/dataclients/UserClient.java
@@ -19,7 +19,7 @@ public class UserClient extends DataClient<UserModel> {
     private final PasswordEncoder passwordEncoder;
 
     public UserClient(Db db, PasswordEncoder passwordEncoder) {
-        super(db);
+        super(db, UserModel.class);
         this.validator = new UserValidator();
         this.passwordEncoder = passwordEncoder;
     }
@@ -38,7 +38,7 @@ public class UserClient extends DataClient<UserModel> {
     }
 
     public UserModel loadById(@NonNull String id) {
-        UserModel userModel = this.getById(UserModel.class, id);
+        UserModel userModel = this.getById(id);
 
         if (userModel == null) {
             String errMessage = String.format("User with id %s not found", id);
@@ -49,11 +49,8 @@ public class UserClient extends DataClient<UserModel> {
     }
 
     public void loginUser(@NonNull UserModel requestUser) {
-        UserModel userModel =  this.getByUniqueField(
-                UserModel.class,
-                USERNAME_FIELD_NAME,
-                requestUser.getUsername()
-        );
+        UserModel userModel =
+                this.getByUniqueField(USERNAME_FIELD_NAME, requestUser.getUsername());
 
         if (userModel == null) {
             String errMessage = "User with username %s not found";


### PR DESCRIPTION
- getById now takes 1 parameter instead of 2
- getByUniqueField now takes 2 parameters instead of 3
- getByField now takes 2 parameters instead of 3

This is good, because every time we call these functions in a typed client we have less arguments to worry about. 
The less arguments to worry about the less noisy it is visually. 