### PR TITLE
feat: add 404 validation to createAccountTransaction path

### DIFF
--- a/backend/src/main/java/org/minttwo/api/spec/account.yaml
+++ b/backend/src/main/java/org/minttwo/api/spec/account.yaml
@@ -152,6 +152,12 @@ paths:
             application/json:
               schema:
                 $ref: './common.yaml#/components/schemas/ErrorDto'
+        '404':
+            description: Account not found
+            content:
+              application/json:
+                schema:
+                  $ref: './common.yaml#/components/schemas/ErrorDto'
         default:
           description: Internal server error
           content:

--- a/backend/src/main/java/org/minttwo/controllers/AccountController.java
+++ b/backend/src/main/java/org/minttwo/controllers/AccountController.java
@@ -98,6 +98,7 @@ public class AccountController implements AccountsApi {
     @Override
     public ResponseEntity<Void> createAccountTransaction(
             CreateAccountTransactionDto createAccountTransactionDto) {
+        accountClient.loadById(createAccountTransactionDto.getAccountId());
         AccountTransactionModel accountTransactionModel =
                 accountAdapter.toCreateAccountTransactionModel(createAccountTransactionDto);
         accountTransactionClient.create(accountTransactionModel);

--- a/backend/src/main/java/org/minttwo/data/dataclients/AccountClient.java
+++ b/backend/src/main/java/org/minttwo/data/dataclients/AccountClient.java
@@ -31,6 +31,10 @@ public class AccountClient extends DataClient<AccountModel> {
         this.insert(accountModel);
     }
 
+    public void update(@NonNull AccountModel accountModel) {
+        super.update(accountModel);
+    }
+
     public AccountModel loadById(@NonNull String id) {
         AccountModel accountModel = this.getById(id);
 


### PR DESCRIPTION
Add updateAccount method to accountClient
Called getAccount on createAccountTransaction API to make sure that the transaction's account exists