### PR TITLE
migration: add name field to account table

### DIFF
--- a/backend/migrations/6-Add_name_field_to_account.sql
+++ b/backend/migrations/6-Add_name_field_to_account.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.account
+ADD name varchar(255) DEFAULT NULL

--- a/backend/migrations/7-Set_name_field_to_required.sql
+++ b/backend/migrations/7-Set_name_field_to_required.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.account
+ALTER COLUMN name SET NOT NULL;


### PR DESCRIPTION
Ran two migrations. 
1st migration inserts name field.
We did a backfill between migrations. 
2nd migration enforces the field to be required. 

### Tradeoffs
We chose not to index the name field, as the user id is enough to get all the accounts to belonging to a user. 